### PR TITLE
Add simulation/RL infrastructure bullet to Mytra Sr Staff role

### DIFF
--- a/resume_2026/index.html
+++ b/resume_2026/index.html
@@ -55,6 +55,7 @@
                     <li>Engineering management position leading a team of 8 across front-end/UI development, data engineering, software tooling, and simulation; responsible for every human-facing surface of the Mytra software stack</li>
                     <li>Rearchitected external UIs and expanded pytest end-to-end and GitHub Actions CI/CD test coverage, reducing human interventions during deployments by 95% and improving system recovery and response time</li>
                     <li>Architected an internal agentic chat service in Python, built in collaboration with Claude Code, featuring swappable model configuration and providing debugging, operational insight, and customer support across local, cloud, and air-gapped deployments</li>
+                    <li>Built simulation infrastructure to train and benchmark RL policies for inventory management and path planning, characterizing optimal control strategies in simulation ahead of field rollout; the same platform regression-tests robotics deployments locally, validating workflows against empirical physical data to catch faults and pinpoint performance gains before deployment</li>
                 </ul>
                 <p class="exp-position">Staff Software Engineer</p>
                 <div class="date-loc-details">


### PR DESCRIPTION
## Summary
Adds a fourth bullet to the **Senior Staff Software Engineer** role at Mytra in the 2026 resume, covering the simulation and infrastructure side of the role:

> Built simulation infrastructure to train and benchmark RL policies for inventory management and path planning, characterizing optimal control strategies in simulation ahead of field rollout; the same platform regression-tests robotics deployments locally, validating workflows against empirical physical data to catch faults and pinpoint performance gains before deployment

## Notes
- Single-line content change to `resume_2026/index.html`.
- Headless render confirms the document still paginates to **2 pages** (8.5×11 Letter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)